### PR TITLE
Installs fixuid

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get -q update \
 #   - colcon build
 #
 FROM ci AS robot
+ARG TARGETPLATFORM
 
 #
 # Ubuntu 24.04 "Noble", which is used as the base image for
@@ -63,7 +64,15 @@ RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && echo "source /usr/share/bash-completion/completions/git" >> /home/$USERNAME/.bashrc
 
 # Install fixuid
-RUN wget -O - https://github.com/boxboat/fixuid/releases/download/v0.6.0/fixuid-0.6.0-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+RUN echo "!!! $TARGETPLATFORM"
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+        ARCH="arm64"; \
+    elif [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+        ARCH="amd64"; \
+    else \
+        exit 1; \
+    fi && \
+    wget -O - https://github.com/boxboat/fixuid/releases/download/v0.6.0/fixuid-0.6.0-linux-$ARCH.tar.gz | tar -C /usr/local/bin -xzf - && \
     chown root:root /usr/local/bin/fixuid && \
     chmod 4755 /usr/local/bin/fixuid && \
     mkdir -p /etc/fixuid && \

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -154,11 +154,11 @@ RUN echo "if [ -f ${USER_WORKSPACE}/install/setup.bash ]; then source ${USER_WOR
     && echo "source $VIRTUAL_ENV/bin/activate" >> /home/$USERNAME/.bashrc \
     && echo "\n# Ensure colcon is run in the venv\nalias colcon='python3 -m colcon'" >> /home/$USERNAME/.bashrc
 
-
 # Actually build workspace
 RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" \
     && colcon build
 
+FROM robot AS desktop
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV GZ_VERSION=harmonic

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -64,7 +64,6 @@ RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && echo "source /usr/share/bash-completion/completions/git" >> /home/$USERNAME/.bashrc
 
 # Install fixuid
-RUN echo "!!! $TARGETPLATFORM"
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
         ARCH="arm64"; \
     elif [ "$TARGETPLATFORM" = "linux/amd64" ]; then \

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -39,6 +39,8 @@ RUN apt-get -q update \
     && rm -rf /var/lib/apt/lists/*
 
 # This stage includes
+#   - Adding the non-root user to sudoers
+#   - Installing and configuring fixuid
 #   - Switching to the non-root user
 #   - Copying 'blue' source from this repo into the non-root user's workspace
 #   - Installing blue deps using pip, apt and rosdep
@@ -50,7 +52,7 @@ FROM ci AS robot
 
 #
 # Ubuntu 24.04 "Noble", which is used as the base image for
-# jazzy and rolling images, now includes a user "ubuntu" at UID 1000
+# jazzy and rolling images, now includes a "built-in" user "ubuntu" at UID 1000
 ARG USERNAME=ubuntu
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
@@ -59,6 +61,16 @@ RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     && usermod -a -G dialout $USERNAME \
     && echo "source /usr/share/bash-completion/completions/git" >> /home/$USERNAME/.bashrc
+
+# Install fixuid
+RUN wget -O - https://github.com/boxboat/fixuid/releases/download/v0.6.0/fixuid-0.6.0-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: ${USERNAME}\ngroup: ${USERNAME}\n" > /etc/fixuid/config.yml
+
+ENTRYPOINT ["fixuid", "-q"]
+CMD ["/bin/bash"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -137,16 +149,16 @@ RUN sudo apt-get -q update \
     && sudo apt-get clean -y \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Actually build workspace
-RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" \
-    && colcon build
-
-RUN echo "source ${USER_WORKSPACE}/install/setup.bash" >> /home/$USERNAME/.bashrc \
+RUN echo "if [ -f ${USER_WORKSPACE}/install/setup.bash ]; then source ${USER_WORKSPACE}/install/setup.bash; fi" >> /home/$USERNAME/.bashrc \
     && echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /home/$USERNAME/.bashrc \
     && echo "source $VIRTUAL_ENV/bin/activate" >> /home/$USERNAME/.bashrc \
     && echo "\n# Ensure colcon is run in the venv\nalias colcon='python3 -m colcon'" >> /home/$USERNAME/.bashrc
 
-FROM robot AS desktop
+
+# Actually build workspace
+RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" \
+    && colcon build
+
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV GZ_VERSION=harmonic


### PR DESCRIPTION
## Changes Made

Installs and configures [fixuid](https://github.com/boxboat/fixuid).   Sets it as the default entrypoint.

It does nothing if the `-u` flag is not passed to Docker.  if a `-u`ser ID is specified, it will chown the appropriate files within the image, simplifying bind mount user ownership issues.

## Associated Issues

n/a

## Testing

Please provide a clear and concise description of the testing performed.
