### PR TITLE
Updates the mavlink repo, removes the hot-patching of the Mavlink code

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -113,19 +113,7 @@ WORKDIR $USER_WORKSPACE/src/
 ARG MAVROS_RELEASE=ros2
 ARG MAVLINK_RELEASE=release/rolling/mavlink
 RUN git clone --depth 1 -b ${MAVROS_RELEASE} https://github.com/mavlink/mavros.git
-RUN git clone --depth 1 --recursive -b ${MAVLINK_RELEASE} https://github.com/mavlink/mavlink-gbp-release.git mavlink
-# - mavgen uses future.standard_library for backwards compatibility with Python2;
-#   However, this caused issues with Python 3.12 installed in "noble".
-#   Comment those lines out in mavlink.
-#
-# - Fix linkage for yaml-cpp in mavros_extra_plugins
-RUN sed -i -e 's/^from future import standard_library/#from future import standard_library/' \
-    -e 's/standard_library.install_aliases()/#standard_library.install_aliases()/' \
-    mavlink/pymavlink/generator/mavgen.py && \
-    sed -i -e 's/^# find_package(yaml_cpp REQUIRED)/find_package(yaml-cpp REQUIRED)/' \
-    -e '/^ament_target_dependencies(mavros_extras_plugins$/i target_link_libraries(mavros_extras_plugins yaml-cpp::yaml-cpp)' \
-    -e '/^ament_target_dependencies(mavros_extras$/i target_link_libraries(mavros_extras yaml-cpp::yaml-cpp)' \
-    mavros/mavros_extras/CMakeLists.txt
+RUN git clone --depth 1 --recursive -b ${MAVLINK_RELEASE} https://github.com/ros2-gbp/mavlink-gbp-release.git mavlink
 
 WORKDIR $USER_WORKSPACE
 RUN sudo apt-get -q update \

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -38,6 +38,12 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          # Pin docker-buildx to this version for now
+          #  v0.19.2 has issues with empty keys,
+          #  particularly the "*.cache-to=" used below
+          #
+          version: v0.18.0
 
       - if: env.PUSH == 'true'
         name: Log into registry

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14194,16 +14194,15 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },


### PR DESCRIPTION
## Changes Made

This PR _still_ builds mavlink and mavros from git repo, but updates the mavlink source repo, and removes the `sed`-based hotpatching.  It isn't needed anymore.

This will fix the current `main` branches but will become obsolete when [blue#324](https://github.com/Robotic-Decision-Making-Lab/blue/pull/324) is merged.

## Testing

Please provide a clear and concise description of the testing performed.
